### PR TITLE
Important bug fix causing swap to fail to be disabled

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -653,7 +653,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    listen-suspend  Copyright (C) 2025  Ben Neilsen
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,52 @@
-This is a script meant to enhance standby power efficiency when suspend is not in-use for the Lenovo Yoga Slim 7i Aura. This is work based on the script provided by [Daniel-42-z](https://github.com/Daniel-42-z/lenovo-yoga-sleep-wake-scripts), but has been heavily modified since then. Suspend, hibernate, and lock behavior should be disabled in Plasma's settings.
+Enhance powered-on idle behavior when suspend is disabled for the Lenovo Yoga Slim 7i Aura.
+Provides options to enter hibernation when the lid is closed.
+This is work based on the script provided by [Daniel-42-z](https://github.com/Daniel-42-z/lenovo-yoga-sleep-wake-scripts), but has been heavily modified since then.
+Currently, this script is not much better than 
+
+# Setup instructions
+* Disable suspend, hibernate, and lock behavior in Plasma's settings.
+* Modify globals in `listen-suspend` then run `install.sh` to create the systemd service.
+* If you configured the script to enter hibernation, then allocate a swap paging file.
 
 # Motivation
-Entering suspend on most Lunar Lake devices results in the keyboard backlight and fans becoming unresponsive, requiring a restart. 
+Entering suspend (s2idle) on LNL causes several issues with devices not functioning on resume, like the keyboard backlight and fans.
+See the following issues:
+* [Lenovo Yoga Slim 7i Aura 15ILL9: fans don't turn on after sleep/resume](https://bbs.archlinux.org/viewtopic.php?id=306675)
+* [Lenovo Yoga Slim 15ILL9 fans completely stop working after suspend/resume cycle, causing dangerous overheating](https://bugzilla.kernel.org/show_bug.cgi?id=220505)
+* [Lenovo Yoga Slim Aura Edition: Keyboard backlight broken after suspend](https://bbs.archlinux.org/viewtopic.php?id=305118)
 
 # Supported Devices
 * Lenovo Yoga Slim 7i Aura (15ILL9)
-* OS: OpenSUSE Tumbleweed (kernel 6.16.3-1-default) and KDE Plasma (6.4.4)
-* Swap: 16 GB / 32 GB depending on your RAM size
+* OS: OpenSUSE Tumbleweed (kernel 6.16) and KDE Plasma (6.4.4)
 
 # Hibernation with temporary swap
-If you have a swap partition, but don't enable it, you must enable the setuid bit for `swapon` and `swapoff` using `sudo chmod u+s /sbin/swapon /sbin/swapoff`. Verify this with `ls -l /sbin/swapon /sbin/swapoff` by looking for `rws`. **Warning**: This action has risks, since now any user can modify your swap! This shouldn't matter though for single-user systems (such as laptops). Make sure to verify that this script's use of `swapon` and `swapoff` is OK for your system, and modify if needed.
+If you are in the subset of users who want hibernation but don't want your swap partition being active, then you must enable the setuid bit for `swapon` and `swapoff` using `sudo chmod u+s /sbin/swapon /sbin/swapoff`.
+Verify this with `ls -l /sbin/swapon /sbin/swapoff` by looking for `rws`.
+**Warning**: This action has risks, since now any user can modify your swap! This shouldn't matter though for single-user systems (such as laptops).
+Make sure to verify that this script's use of `swapon` and `swapoff` is OK for your system, and modify if needed.
 
-# Warnings
-Running this script without understanding how it works can result in your system being soft bricked, requiring a restart. Please test this script first. This script is a **work in progress** and does not provide a warranty. Make sure you have enough swap for hibernation or that you disable the feature.
+# Specify always-on hours with cron
+Use `extend-timer` to delay the script's hibernation timer.
+Relies on a shared memory file in `/dev/shm` to send signals to the main script.
+See `extend-timer` for instructions on how this works.
 
 # How it works
-When `dbus` detects that your lid has closed it will turn the screen off using `kscreen-doctor`, lock your session, disable all radios using `rfkill`, and switch off the keyboard backlight. When `dbus` receives an "open lid" event it will restore the previous state of your radios and switch your screen back on. Whether it is able to restore the keyboard backlight is finnicky and may not work every time due to firmware.
+When `dbus` detects that your lid has closed it will turn the screen off using `kscreen-doctor`, lock your session, disable all radios using `rfkill`, and switch off the keyboard backlight. 
+When `dbus` receives an "open lid" event it will restore the previous state of your radios and switch your screen back on.
+Whether it is able to restore the keyboard backlight is finnicky and may not work every time due to firmware.
 
-The script is configured to wait a custom amount of time *off the plug* before hibernating in this state. That time starts when you unplug from AC and resets when you plug back in. I haven't thoroughly tested this but it should work. This feature was added to limit the use of hibernation to long-term breaks.
+The script is configured to wait a custom amount of time *off the plug* before hibernating in this state.
+That time starts when you unplug from AC and resets when you plug back in.
+I haven't thoroughly tested this but it should work.
+This feature was added to limit the use of hibernation to long-term breaks.
 
 # Results
-With the CPU at idle and everything off, I measured about 1 watt being discharged from the battery. With hibernation set to kick in after 30 minutes, this is about 0.5 watt-hours lost or 0.7% of your battery charge.
+With the CPU at idle and everything off, I measured about 1 watt being discharged from the battery.
+With hibernation set to kick in after 30 minutes, this is about 0.5 watt-hours lost or 0.7% of your battery charge.
+Since nothing in userspace is actually paused, this isn't much better than just letting your laptop screen turn off.
+
+# Warnings
+Running this script without understanding how it works can result in your system being soft bricked, requiring a restart.
+Please test this script first in a safe environment.
+This script is a **work in progress** and does not provide a warranty.
+Make sure you have enough swap for hibernation or that you disable the feature (test run `systemctl hibernate` once).

--- a/extend-timer
+++ b/extend-timer
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# project-specific file that  signals to
+# the listener script to extend its
+# hibernation timer by 1 minute.
+#
+# this file is deleted or "consumed" when
+# it is read by the listener, so it must be
+# created every minute by cron
+#
+# the trailing number is just a random identifier
+touch /dev/shm/extend-timer-4865
+
+# this script is best called by cron.
+# here is an example cron script:
+
+#ET=/usr/local/bin/extend-timer
+#0-50 10-11 * * 1 $ET
+#0-50 15 * * 1    $ET
+
+# meaning: on monday, from 10-10:50, 11-11:50,
+# and 3-3:50, run extend-timer every minute.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 sudo cp listen-suspend /usr/local/bin/
+sudo cp extend-timer /usr/local/bin/
 sudo cp listen-suspend.service /etc/systemd/user
 
 systemctl --user daemon-reload

--- a/listen-suspend
+++ b/listen-suspend
@@ -207,6 +207,21 @@ can_hibernate() {
 	return $status
 }
 
+block_on_sysclock() {
+	# https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
+	# SECONDS - "The number of seconds at shell invocation and the current time
+	# are always determined by querying the system clock at one-second resolution"
+	block_time="$1"
+	start="$SECONDS"
+	while true; do
+		diff="$(($SECONDS-$start))"
+		if [ "$diff" -ge "$block_time" ]; then
+			break
+		fi
+		sleep 0.5
+	done
+}
+
 # wait_hibernate() : put the computer to hibernation if can_hibernate() says so, and updates drain variable.
 # params: none
 # returns: none
@@ -232,7 +247,19 @@ wait_hibernate() {
 			echo_if_debug "Enabling swap."
 			swapon -a
 		fi
+		# systemctl(1): "It will not wait for the hibernate/thaw cycle to complete."
+		# Unfortunately, the --wait option does not work with hibernate.
 		systemctl hibernate
+		status=$?
+		if [ "$status" -ne 0 ]; then
+			echo_if_debug "Hibernation failed. Check your swap file."
+		fi
+
+		# Expectation is that there are at least X seconds from the point that a computer
+		# queues hibernation to when it resumes from hibernation, but that hibernate takes less time
+		# to shutdown. This relies on the system clock rather than the monotonic clock used in sleep.
+		block_on_sysclock 15
+
 		echo_if_debug "Left hibernation at time=$SECONDS."
 		_wake
 		if [ "$SWAP_WHEN_HIBERNATE" -eq 1 ] ; then

--- a/listen-suspend
+++ b/listen-suspend
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # Only tested for:
 # Lenovo Yoga Slim 7i Aura Edition
@@ -13,6 +13,7 @@ WIFI_ENABLED=
 BT_ENABLED=
 KB_BACKLIGHT=
 STANDBY_DRAIN_START=-1
+EXTEND_TIMER_FILE="/dev/shm/extend-timer-4865"
 
 # the amount of time to wait in idle before entering hibernation
 # set this to zero (0) to disable this entirely.
@@ -43,6 +44,18 @@ fi
 echo_if_debug() {
 	[ "${DEBUG:-0}" -eq 1 ] && echo "$1"
 	return 0
+}
+
+# check_timer() : output "1" if the timer needs to be extended, output "0" otherwise
+# the function that calls check_timer() must save its output since the internal file
+# it checks is consumed immediately.
+check_timer() {
+	if [ -f "$EXTEND_TIMER_FILE" ]; then
+		rm "$EXTEND_TIMER_FILE"
+		echo 1
+	else
+		echo 0
+	fi
 }
 
 _is_radio_blocked() {
@@ -207,17 +220,28 @@ wait_hibernate() {
 		update_standby_drain_start
 	fi
 
+	if [ "$(check_timer)" -eq 1 ] && [ "$STANDBY_DRAIN_START" -ne -1 ]; then
+		echo_if_debug "Extending standby."
+		STANDBY_DRAIN_START=$(("$STANDBY_DRAIN_START+60"))
+	fi
+
 	if can_hibernate
 	then
 		echo_if_debug "Entering hibernation."
 		if [ "$SWAP_WHEN_HIBERNATE" -eq 1 ] ; then
+			echo_if_debug "Enabling swap."
 			swapon -a
 		fi
 		systemctl hibernate
 		echo_if_debug "Left hibernation at time=$SECONDS."
 		_wake
 		if [ "$SWAP_WHEN_HIBERNATE" -eq 1 ] ; then
+			echo_if_debug "Disabling swap."
 			swapoff -a
+			success=$?
+			if [ "$success" -ne 0 ] ; then
+				echo_if_debug "Warning: Swap not disabled."
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
Script did not wait for hibernate to finish before disabling swap, since the hibernate command queues and does not block.